### PR TITLE
Add license, changelog and gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,19 @@
+# Ignore bundler config
+.bundle/
+
+# Ignore test coverage reports
+coverage/
+
+# Ignore packaged gems and build artifacts
+pkg/
+*.gem
+
+# Ignore log files
+log/
+
+# Ignore yard documentation
+.yardoc/
+
+# Ignore temporary files
+*.swp
+.DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
 # Changelog
 
-All notable changes to this project will be documented in this file.
-
+## [0.1.0] - 2025-08-01
+- Initial release.

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,2 +1,21 @@
 MIT License
 
+Copyright (c) 2025 fk1018
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/obd2.gemspec
+++ b/obd2.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.metadata["changelog_uri"]     = "#{spec.homepage}/blob/main/CHANGELOG.md"
 
   # Files to be packaged with the gem
-  spec.files         = Dir["lib/**/*", "README.md", "LICENSE.txt", "CHANGELOG.md"]
+  spec.files         = Dir["lib/**/*", "README.md", "LICENSE.txt", "CHANGELOG.md", ".gitignore"]
   spec.require_paths = ["lib"]
 
   # Declare runtime dependencies.  The OBD2 gem depends on can_messenger


### PR DESCRIPTION
## Summary
- fill in MIT license text
- start a CHANGELOG with version 0.1.0
- create a .gitignore for common build artifacts
- include new files in the gemspec

## Testing
- `bundle install`
- `bundle exec rspec`

------
https://chatgpt.com/codex/tasks/task_e_688d1aeadfc483208bdde72fbef8e644

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a .gitignore file to exclude unnecessary files and directories from version control.
  * Updated the changelog with a version header and release date for the initial release.
  * Included the full text of the MIT License in the license file.
  * Ensured the .gitignore file is packaged with the gem.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->