### PR TITLE
Update README with prerequisites and add AGENTS guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,10 @@
+# Agent Guidelines
+
+This repository uses Ruby with Bundler. When modifying code:
+
+- Install dependencies with `bundle install` if needed.
+- Run the test suite via `bundle exec rspec` and ensure it passes before committing.
+- Follow the existing coding style; `rubocop` is not configured, so rely on idiomatic Ruby.
+- Keep this file up to date with any new conventions or commands useful for agents.
+
+

--- a/README.md
+++ b/README.md
@@ -10,11 +10,18 @@ Clone the repository and install dependencies with:
 bundle install
 ```
 
-To build the gem locally and push it to RubyGems:
+Prerequisites
+-------------
+- Ruby ≥ 3.0 (check with `ruby -v`)
+- Bundler (`gem install bundler`)
+
+### Building & publishing (maintainers only)
+
+To build the gem locally and, if you are an authorised maintainer, push it to RubyGems:
 
 ```bash
 gem build obd2.gemspec
-gem push obd2-*.gem
+gem push obd2-*.gem  # requires RubyGems credentials
 ```
 
 ## Usage
@@ -22,7 +29,7 @@ gem push obd2-*.gem
 ```ruby
 require "obd2"
 
-client = Obd2::Client.new(interface_name: "can0")
+client = Obd2::Client.new(interface_name: "can0") # make sure `can0` exists (e.g. SocketCAN)
 result = client.request_pid(service: 0x01, pid: 0x0C)
 puts result.inspect
 ```


### PR DESCRIPTION
## Summary
- clarify required Ruby version and bundler install
- note publishing is for maintainers only and requires credentials
- explain that a CAN interface like `can0` must exist
- create `AGENTS.md` with basic instructions for contributors

## Testing
- `bundle exec rspec`

------
https://chatgpt.com/codex/tasks/task_e_688d23eaac308320b3938d72482adec0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new AGENTS.md file with contributor guidelines for the Ruby codebase.
  * Updated the README with a "Prerequisites" section, clearer build and publishing instructions, and an example code comment about CAN interface requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->