### PR TITLE
Apply doc updates and add RuboCop config

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,4 +10,4 @@ Style/StringLiteralsInInterpolation:
   EnforcedStyle: double_quotes
 
 Metrics/BlockLength:
-  AllowedMethods: ['describe', 'context']
+  AllowedMethods: ["describe", "context"]

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,13 @@
+AllCops:
+  TargetRubyVersion: 3.0
+  NewCops: enable
+  SuggestExtensions: false
+
+Style/StringLiterals:
+  EnforcedStyle: double_quotes
+
+Style/StringLiteralsInInterpolation:
+  EnforcedStyle: double_quotes
+
+Metrics/BlockLength:
+  AllowedMethods: ['describe', 'context']

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,10 +1,11 @@
-# Agent Guidelines
+# Contributor Guide
 
 This repository uses Ruby with Bundler. When modifying code:
 
-- Install dependencies with `bundle install` if needed.
+- Ensure you are on **Ruby ≥ 3.0** and have Bundler installed (`gem install bundler`).
+- Install dependencies with `bundle install`.
 - Run the test suite via `bundle exec rspec` and ensure it passes before committing.
-- Follow the existing coding style; `rubocop` is not configured, so rely on idiomatic Ruby.
+- Follow the existing coding style. Run `rubocop -a` to check for style violations.
 - Keep this file up to date with any new conventions or commands useful for agents.
 
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,9 +7,21 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    ast (2.4.3)
     can_messenger (1.4.0)
     diff-lcs (1.6.2)
     docile (1.4.1)
+    json (2.13.2)
+    language_server-protocol (3.17.0.5)
+    lint_roller (1.1.0)
+    parallel (1.27.0)
+    parser (3.3.9.0)
+      ast (~> 2.4.1)
+      racc
+    prism (1.4.0)
+    racc (1.8.1)
+    rainbow (3.1.1)
+    regexp_parser (2.10.0)
     rspec (3.13.1)
       rspec-core (~> 3.13.0)
       rspec-expectations (~> 3.13.0)
@@ -23,12 +35,30 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
     rspec-support (3.13.4)
+    rubocop (1.79.1)
+      json (~> 2.3)
+      language_server-protocol (~> 3.17.0.2)
+      lint_roller (~> 1.1.0)
+      parallel (~> 1.10)
+      parser (>= 3.3.0.2)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 2.9.3, < 3.0)
+      rubocop-ast (>= 1.46.0, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 2.4.0, < 4.0)
+    rubocop-ast (1.46.0)
+      parser (>= 3.3.7.2)
+      prism (~> 1.4)
+    ruby-progressbar (1.13.0)
     simplecov (0.22.0)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.13.2)
     simplecov_json_formatter (0.1.4)
+    unicode-display_width (3.1.4)
+      unicode-emoji (~> 4.0, >= 4.0.4)
+    unicode-emoji (4.0.4)
 
 PLATFORMS
   ruby
@@ -37,6 +67,7 @@ PLATFORMS
 DEPENDENCIES
   obd2!
   rspec (~> 3.12)
+  rubocop (~> 1.59)
   simplecov (~> 0.22)
 
 BUNDLED WITH

--- a/README.md
+++ b/README.md
@@ -10,8 +10,7 @@ Clone the repository and install dependencies with:
 bundle install
 ```
 
-Prerequisites
--------------
+## Prerequisites
 - Ruby ≥ 3.0 (check with `ruby -v`)
 - Bundler (`gem install bundler`)
 

--- a/obd2.gemspec
+++ b/obd2.gemspec
@@ -36,6 +36,7 @@ Gem::Specification.new do |spec|
   # Development dependencies for running the test suite
   spec.add_development_dependency "rspec", "~> 3.12"
   spec.add_development_dependency "simplecov", "~> 0.22"
+  spec.add_development_dependency "rubocop", "~> 1.59"
 
   # Enforce MFA for publishing
   spec.metadata["rubygems_mfa_required"] = "true"


### PR DESCRIPTION
## Summary
- expand contributor instructions in `AGENTS.md`
- normalize heading style in README
- add `.rubocop.yml` and rubocop dev dependency

## Testing
- `bundle install`
- `bundle exec rubocop`
- `bundle exec rspec`

------
https://chatgpt.com/codex/tasks/task_e_688d265991308320b3f2a4f0a664064a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Introduced RuboCop configuration and added RuboCop as a development dependency to enforce consistent code style.
* **Documentation**
  * Updated contributor guidelines to require Ruby 3.0+, Bundler, and use of RuboCop for code style.
  * Improved README formatting for the prerequisites section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->