### PR TITLE
Validate response frame structure

### DIFF
--- a/.coderabbit.yml
+++ b/.coderabbit.yml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+language: "en-US"
+early_access: false
+reviews:
+  profile: "chill"
+  request_changes_workflow: false
+  high_level_summary: true
+  poem: true
+  review_status: true
+  collapse_walkthrough: false
+  auto_review:
+    enabled: true
+    drafts: false
+    base_branches:
+      - staging
+chat:
+  auto_reply: true

--- a/spec/lib/obd2/decoder_spec.rb
+++ b/spec/lib/obd2/decoder_spec.rb
@@ -31,5 +31,20 @@ RSpec.describe Obd2::Decoder do
     it "raises an error when data length is insufficient" do
       expect { decoder.decode(0x7E8, [1, 2]) }.to raise_error(ArgumentError)
     end
+
+    it "raises an error when response service is below 0x40" do
+      data = [4, 0x01, 0x0C, 0x00, 0x00, 0, 0, 0]
+      expect { decoder.decode(0x7E8, data) }.to raise_error(ArgumentError)
+    end
+
+    it "raises an error when payload length does not match PID expectation" do
+      data = [5, 0x41, 0x0C, 0x00, 0x00, 0, 0, 0]
+      expect { decoder.decode(0x7E8, data) }.to raise_error(ArgumentError)
+    end
+
+    it "raises an error when not enough data bytes follow" do
+      data = [4, 0x41, 0x0C, 0x00]
+      expect { decoder.decode(0x7E8, data) }.to raise_error(ArgumentError)
+    end
   end
 end


### PR DESCRIPTION
## Summary
- validate response service byte and expected payload length in `Decoder#decode`
- cover malformed responses with additional decoder specs

## Testing
- `rubocop -a`
- `bundle exec rspec`


------
https://chatgpt.com/codex/tasks/task_e_688fa31ad4e883208b4d68c8638aab86

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Introduced a new configuration file to set language preferences and adjust review settings, including enabling high-level summaries and auto review for specific branches.

* **Bug Fixes**
  * Improved validation in OBD2 data decoding to handle malformed or invalid response frames more robustly, ensuring stricter error handling for incorrect payloads and response formats.

* **Tests**
  * Added new test cases to verify that decoding errors are properly raised for various types of malformed OBD2 frames.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->