### PR TITLE
docs: update installation and requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,26 @@
 # OBD2
 
-A simple Ruby wrapper for reading and decoding OBD-II messages over the CAN bus.
+A simple Ruby wrapper for reading and decoding OBD-II messages over the CAN bus. It relies on the
+`can_messenger` gem to communicate over a working SocketCAN interface. Currently, only single-frame
+PID requests are supported.
 
 ## Installation
 
-Clone the repository and install dependencies with:
+### Using RubyGems
+
+```bash
+gem install obd2
+```
+
+### Using Bundler
+
+Add the gem to your `Gemfile`:
+
+```ruby
+gem "obd2"
+```
+
+Then install dependencies with:
 
 ```bash
 bundle install
@@ -13,6 +29,8 @@ bundle install
 ## Prerequisites
 - Ruby ≥ 3.0 (check with `ruby -v`)
 - Bundler (`gem install bundler`)
+- A working SocketCAN interface (e.g. `can0`)
+- The `can_messenger` gem (installed automatically as a dependency)
 
 ### Building & publishing (maintainers only)
 
@@ -32,6 +50,8 @@ client = Obd2::Client.new(interface_name: "can0") # make sure `can0` exists (e.g
 result = client.request_pid(service: 0x01, pid: 0x0C)
 puts result.inspect
 ```
+
+Only single-frame PID requests are currently supported.
 
 ## Running Tests
 


### PR DESCRIPTION
## Summary
- document installation via RubyGems and Bundler
- note requirement for can_messenger and a SocketCAN interface
- clarify that only single-frame PID requests are supported

## Testing
- `bundle exec rubocop -a`
- `bundle exec rspec`


------
https://chatgpt.com/codex/tasks/task_e_688faa3a82048320b82919bb10eabc1c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded installation instructions with separate sections for RubyGems and Bundler.
  * Clarified dependency on the can_messenger gem and requirement for a working SocketCAN interface.
  * Updated gem description and usage examples to specify support for single-frame PID requests only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->