### PR TITLE
Enforce timeout in PID request handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,14 +51,34 @@ result = client.request_pid(service: 0x01, pid: 0x0C)
 puts result.inspect
 ```
 
-Only single-frame PID requests are currently supported.
+Only single-frame PID requests are currently supported. `request_pid` returns
+`nil` if no response is received before the timeout (default 1 second) and will
+block until either a response is decoded or the timeout expires.
+
+## Custom PIDs
+
+Additional PIDs can be registered at runtime by adding entries to
+`Obd2::PIDS::REGISTRY`:
+
+```ruby
+Obd2::PIDS::REGISTRY[[0x01, 0x42]] = Obd2::PID.new(
+  service: 0x01,
+  pid: 0x42,
+  name: "Control Module Voltage",
+  description: "Control module voltage",
+  bytes: 2,
+  unit: "V",
+  formula: ->(a, b) { ((a << 8) | b) / 1000.0 }
+)
+```
 
 ## Running Tests
 
-Execute the test suite with:
+Execute the test suite and rubocop with:
 
 ```bash
 bundle exec rspec
+bundle exec rubocop -a
 ```
 
 ## License


### PR DESCRIPTION
## Summary
- Ensure `Client#request_pid` respects the timeout even when no CAN messages arrive, returning `nil` on timeout.
- Document custom PID registration and note that `request_pid` may block until timeout.
- Mention running `rubocop -a` alongside tests in development instructions.

## Testing
- `bundle exec rubocop -a`
- `bundle exec rspec`


------
https://chatgpt.com/codex/tasks/task_e_688fb7a2cddc8320a12494542552b53c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the README to clarify timeout behavior, add instructions for custom PIDs, and expand test instructions.

* **Bug Fixes**
  * Improved the timeout handling in the request process to use Ruby's built-in timeout mechanism for greater reliability.

* **Tests**
  * Added a test to verify correct timeout behavior when no response is received.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->