### PR TITLE
Document request_pid options and refine packaging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
 
+## [Unreleased]
+- Document optional parameters for `Obd2::Client#request_pid`.
+- Stop packaging `.gitignore` to avoid shipping developer artifacts.
+
 ## [0.1.0] - 2025-08-01
 - Initial release.

--- a/README.md
+++ b/README.md
@@ -55,6 +55,24 @@ Only single-frame PID requests are currently supported. `request_pid` returns
 `nil` if no response is received before the timeout (default 1 second) and will
 block until either a response is decoded or the timeout expires.
 
+The method also accepts optional parameters:
+
+* `request_id` – CAN identifier used for the request (default `0x7DF`).
+* `response_filter` – CAN IDs to listen for in responses (default `0x7E8..0x7EF`).
+* `timeout` – Seconds to wait for a response (default `1.0`).
+
+For example:
+
+```ruby
+result = client.request_pid(
+  service: 0x01,
+  pid: 0x0C,
+  request_id: 0x7E0,
+  response_filter: 0x7E8,
+  timeout: 2.0
+)
+```
+
 ## Custom PIDs
 
 Additional PIDs can be registered at runtime by adding entries to

--- a/obd2.gemspec
+++ b/obd2.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.metadata["changelog_uri"]     = "#{spec.homepage}/blob/main/CHANGELOG.md"
 
   # Files to be packaged with the gem
-  spec.files         = Dir["lib/**/*", "README.md", "LICENSE.txt", "CHANGELOG.md", ".gitignore"]
+  spec.files         = Dir["lib/**/*", "README.md", "LICENSE.txt", "CHANGELOG.md"]
   spec.require_paths = ["lib"]
 
   # Declare runtime dependencies.  The OBD2 gem depends on can_messenger


### PR DESCRIPTION
## Summary
- document optional parameters for `Obd2::Client#request_pid`
- avoid shipping `.gitignore` in the gem
- note doc and packaging updates in changelog

## Testing
- `bundle install`
- `bundle exec rubocop -a`
- `bundle exec rspec`
- `gem build obd2.gemspec`


------
https://chatgpt.com/codex/tasks/task_e_688fcda06a4883209832c697a016b49f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the README to clarify optional parameters for the `request_pid` method and added an example usage.
  * Added an "Unreleased" section to the changelog with recent documentation and packaging changes.

* **Chores**
  * Adjusted packaging settings to exclude `.gitignore` files from the distributed gem.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->