### PR TITLE
docs: expand SocketCAN prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,12 @@ bundle install
 ## Prerequisites
 - Ruby ≥ 3.0 (check with `ruby -v`)
 - Bundler (`gem install bundler`)
-- A working SocketCAN interface (e.g. `can0`)
+- A working SocketCAN interface (e.g. `can0`). See the [official SocketCAN setup instructions](https://www.kernel.org/doc/html/latest/networking/can.html). To create a virtual interface for testing:
+
+  ```bash
+  sudo ip link add dev can0 type vcan
+  sudo ip link set can0 up
+  ```
 - The `can_messenger` gem (installed automatically as a dependency)
 
 ### Building & publishing (maintainers only)

--- a/README.md
+++ b/README.md
@@ -31,10 +31,22 @@ bundle install
 - Bundler (`gem install bundler`)
 - A working SocketCAN interface (e.g. `can0`). See the [official SocketCAN setup instructions](https://www.kernel.org/doc/html/latest/networking/can.html). To create a virtual interface for testing:
 
-  ```bash
-  sudo ip link add dev can0 type vcan
-  sudo ip link set can0 up
-  ```
++  ```bash
++  # Load the virtual-CAN kernel module (needed once per boot)
++  sudo modprobe vcan
++
++  # Create and bring up a virtual CAN interface called vcan0
++  sudo ip link add dev vcan0 type vcan
++  sudo ip link set vcan0 up
++  ```
+
+or
+
+-  ```bash
+-  sudo ip link add dev can0 type vcan
+-  sudo ip link set can0 up
+-  ```
+
 - The `can_messenger` gem (installed automatically as a dependency)
 
 ### Building & publishing (maintainers only)

--- a/README.md
+++ b/README.md
@@ -27,25 +27,24 @@ bundle install
 ```
 
 ## Prerequisites
+
 - Ruby ≥ 3.0 (check with `ruby -v`)
 - Bundler (`gem install bundler`)
 - A working SocketCAN interface (e.g. `can0`). See the [official SocketCAN setup instructions](https://www.kernel.org/doc/html/latest/networking/can.html). To create a virtual interface for testing:
 
-+  ```bash
-+  # Load the virtual-CAN kernel module (needed once per boot)
-+  sudo modprobe vcan
-+
-+  # Create and bring up a virtual CAN interface called vcan0
-+  sudo ip link add dev vcan0 type vcan
-+  sudo ip link set vcan0 up
-+  ```
+* ```bash
 
-or
+  ```
 
--  ```bash
--  sudo ip link add dev can0 type vcan
--  sudo ip link set can0 up
--  ```
+* # Load the virtual-CAN kernel module (needed once per boot)
+* sudo modprobe vcan
+*
+* # Create and bring up a virtual CAN interface called vcan0
+* sudo ip link add dev vcan0 type vcan
+* sudo ip link set vcan0 up
+* ```
+
+  ```
 
 - The `can_messenger` gem (installed automatically as a dependency)
 
@@ -74,9 +73,9 @@ block until either a response is decoded or the timeout expires.
 
 The method also accepts optional parameters:
 
-* `request_id` – CAN identifier used for the request (default `0x7DF`).
-* `response_filter` – CAN IDs to listen for in responses (default `0x7E8..0x7EF`).
-* `timeout` – Seconds to wait for a response (default `1.0`).
+- `request_id` – CAN identifier used for the request (default `0x7DF`).
+- `response_filter` – CAN IDs to listen for in responses (default `0x7E8..0x7EF`).
+- `timeout` – Seconds to wait for a response (default `1.0`).
 
 For example:
 

--- a/README.md
+++ b/README.md
@@ -30,21 +30,16 @@ bundle install
 
 - Ruby ≥ 3.0 (check with `ruby -v`)
 - Bundler (`gem install bundler`)
-- A working SocketCAN interface (e.g. `can0`). See the [official SocketCAN setup instructions](https://www.kernel.org/doc/html/latest/networking/can.html). To create a virtual interface for testing:
+- A working SocketCAN interface (e.g. `vcan0`). See the [official SocketCAN setup instructions](https://www.kernel.org/doc/html/latest/networking/can.html). To create a virtual interface for testing:
 
-* ```bash
+```bash
+# Load the virtual-CAN kernel module (needed once per boot)
+sudo modprobe vcan
 
-  ```
-
-* # Load the virtual-CAN kernel module (needed once per boot)
-* sudo modprobe vcan
-*
-* # Create and bring up a virtual CAN interface called vcan0
-* sudo ip link add dev vcan0 type vcan
-* sudo ip link set vcan0 up
-* ```
-
-  ```
+# Create and bring up a virtual CAN interface called vcan0
+sudo ip link add dev vcan0 type vcan
+sudo ip link set vcan0 up
+```
 
 - The `can_messenger` gem (installed automatically as a dependency)
 
@@ -62,7 +57,7 @@ gem push obd2-*.gem  # requires RubyGems credentials
 ```ruby
 require "obd2"
 
-client = Obd2::Client.new(interface_name: "can0") # make sure `can0` exists (e.g. SocketCAN)
+client = Obd2::Client.new(interface_name: "vcan0") # make sure `vcan0` exists (e.g. SocketCAN)
 result = client.request_pid(service: 0x01, pid: 0x0C)
 puts result.inspect
 ```


### PR DESCRIPTION
## Summary
- clarify SocketCAN requirements in README and link to official docs
- add example commands for creating a `can0` interface

## Testing
- `bundle exec rspec`
- `bundle exec rubocop -a`


------
https://chatgpt.com/codex/tasks/task_e_688fdfe176cc8320be12ec099f286e18

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded the README's Prerequisites section with detailed instructions and examples for setting up a virtual CAN interface, including a link to official setup documentation and example commands for testing.  
  * Improved formatting of optional parameters in the README for better clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->