### PR TITLE
Exclude .gitignore from packaged gem

### DIFF
--- a/obd2.gemspec
+++ b/obd2.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
 
   # Files to be packaged with the gem
   spec.files = `git ls-files -z`.split("\x0").reject do |f|
-    f.start_with?("spec/", ".git", ".rubocop", ".coderabbit") || f == "Gemfile.lock"
+    f.start_with?("spec/", ".git", ".rubocop", ".coderabbit") || f == "Gemfile.lock" || f == ".gitignore"
   end
   spec.require_paths = ["lib"]
 


### PR DESCRIPTION
## Summary
- avoid packaging `.gitignore`
- note packaging change under 'Unreleased' in the changelog

## Testing
- `bundle exec rubocop -a`
- `bundle exec rspec`
- `gem build obd2.gemspec`
- `tar tzf data.tar.gz`


------
https://chatgpt.com/codex/tasks/task_e_688fef263be88320a12c309f4613e2dd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated packaging settings to exclude the `.gitignore` file from the gem package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->