### PR TITLE
Allow modifying PID registry at runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,8 +86,8 @@ result = client.request_pid(
 
 ## Custom PIDs
 
-Additional PIDs can be registered at runtime by adding entries to
-`Obd2::PIDS::REGISTRY`:
+`Obd2::PIDS::REGISTRY` is a mutable hash, so additional PIDs can be
+registered at runtime by adding entries:
 
 ```ruby
 Obd2::PIDS::REGISTRY[[0x01, 0x42]] = Obd2::PID.new(

--- a/lib/obd2/pids.rb
+++ b/lib/obd2/pids.rb
@@ -15,7 +15,10 @@ module Obd2
   module PIDS
     module_function
 
-    # A frozen hash mapping `(service, pid)` tuples to {PID} objects.
+    # A hash mapping `(service, pid)` tuples to {PID} objects. The
+    # registry is mutable so additional PIDs can be registered at
+    # runtime by assigning new entries.
+    # rubocop:disable Style/MutableConstant
     REGISTRY = {
       # Service 0x01 (Show current data)
       [0x01, 0x0C] => PID.new(
@@ -63,7 +66,8 @@ module Obd2
         unit: "%",
         formula: ->(a) { (a * 100.0) / 255.0 }
       )
-    }.freeze
+    }
+    # rubocop:enable Style/MutableConstant
 
     # Lookup a PID definition by its service and pid.  Returns nil if
     # no matching entry exists.

--- a/spec/lib/obd2/pids_spec.rb
+++ b/spec/lib/obd2/pids_spec.rb
@@ -14,5 +14,24 @@ RSpec.describe Obd2::PIDS do
       expect(pid.name).to eq("Engine RPM")
       expect(pid.unit).to eq("rpm")
     end
+
+    it "allows registering additional PID definitions" do
+      custom_pid = Obd2::PID.new(
+        service: 0x01,
+        pid: 0x42,
+        name: "Control Module Voltage",
+        description: "Control module voltage",
+        bytes: 2,
+        unit: "V",
+        formula: ->(a, b) { ((a << 8) | b) / 1000.0 }
+      )
+
+      begin
+        described_class::REGISTRY[[0x01, 0x42]] = custom_pid
+        expect(described_class.find(0x01, 0x42)).to be(custom_pid)
+      ensure
+        described_class::REGISTRY.delete([0x01, 0x42])
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary
- make Obd2::PIDS::REGISTRY mutable to allow runtime extensions
- document mutable PID registry in README
- test adding custom PIDs at runtime

## Testing
- `bundle exec rubocop -a`
- `bundle exec rspec`


------
https://chatgpt.com/codex/tasks/task_e_6890e8b10ed48320a7ad5acbeea08836

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the README to explicitly state that custom PIDs can be registered at runtime by modifying the registry.

* **Bug Fixes**
  * Made the PID registry mutable, allowing additional PIDs to be registered during runtime.

* **Tests**
  * Added a test to verify that custom PIDs can be dynamically added to the registry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->