### PR TITLE
Handle malformed CAN frames gracefully

### DIFF
--- a/lib/obd2/client.rb
+++ b/lib/obd2/client.rb
@@ -54,7 +54,11 @@ module Obd2
         Timeout.timeout(timeout) do
           @messenger.start_listening(filter: response_filter) do |message|
             # Each message is a hash with :id and :data; decode it
-            decoded = @decoder.decode(message[:id], message[:data])
+            begin
+              decoded = @decoder.decode(message[:id], message[:data])
+            rescue ArgumentError
+              next
+            end
             next unless decoded
 
             result = decoded


### PR DESCRIPTION
## Summary
- handle ArgumentError from decoder to ignore malformed frames
- test that malformed frames are skipped and don't crash client

## Testing
- `bundle exec rubocop -a`
- `bundle exec rspec`


------
https://chatgpt.com/codex/tasks/task_e_6890eb403f3483208ad8deed713ea9de

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling to ensure the app continues processing messages even if some are malformed, preventing interruptions during message decoding.

* **Tests**
  * Added tests to verify correct behavior when handling malformed messages, ensuring the app ignores errors and continues processing or returns nil if all messages are invalid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->