### PR TITLE
Start listener before sending request

### DIFF
--- a/lib/obd2/client.rb
+++ b/lib/obd2/client.rb
@@ -67,7 +67,9 @@ module Obd2
             end
           end
 
-          sleep 0.01
+          # Yield to the listener thread so it can begin processing before
+          # sending the request frame.
+          Thread.pass
           @messenger.send_can_message(id: frame[:id], data: frame[:data])
           listener.join
         end


### PR DESCRIPTION
## Summary
- ensure the CAN messenger listener is running before sending PID requests
- update client specs to expect the listener to start before transmitting frames

## Testing
- `bundle exec rubocop -a`
- `bundle exec rspec`


------
https://chatgpt.com/codex/tasks/task_e_6890f87725f48320999dce74fab5a111

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CAN message handling by starting the response listener before sending requests to enhance reliability.

* **Tests**
  * Enforced strict order in tests to verify the listener starts before sending CAN messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->