### PR TITLE
Handle PCI single frame and add tests

### DIFF
--- a/lib/obd2/decoder.rb
+++ b/lib/obd2/decoder.rb
@@ -17,11 +17,14 @@ module Obd2
     # @param data [Array<Integer>] Eight data bytes from the CAN frame.
     # @return [Hash, nil] Parsed response or nil if PID not found.
     # @raise [ArgumentError] If fewer than three bytes of data are supplied.
-    # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
+    # rubocop:disable Metrics/MethodLength, Metrics/AbcSize, Metrics/CyclomaticComplexity
     def decode(can_id, data)
       raise ArgumentError, "Data must contain at least 3 bytes" if data.length < 3
 
-      frame_len  = data[0]
+      pci = data[0]
+      raise ArgumentError, "Unsupported PCI frame type" unless (pci >> 4).zero?
+
+      frame_len  = pci & 0x0F
       resp_svc   = data[1]
       resp_pid   = data[2]
       # According to the OBD‑II spec, response service = request service + 0x40.
@@ -49,6 +52,6 @@ module Obd2
         pid_def: pid_def
       }
     end
-    # rubocop:enable Metrics/MethodLength, Metrics/AbcSize
+    # rubocop:enable Metrics/MethodLength, Metrics/AbcSize, Metrics/CyclomaticComplexity
   end
 end

--- a/spec/lib/obd2/decoder_spec.rb
+++ b/spec/lib/obd2/decoder_spec.rb
@@ -47,4 +47,19 @@ RSpec.describe Obd2::Decoder do
       expect { decoder.decode(0x7E8, data) }.to raise_error(ArgumentError)
     end
   end
+
+  context "with PCI values" do
+    it "accepts single-frame PCI values" do
+      speed = 50
+      data  = [0x03, 0x41, 0x0D, speed, 0, 0, 0, 0]
+      result = decoder.decode(0x7E8, data)
+      expect(result).not_to be_nil
+      expect(result[:value]).to eq(speed)
+    end
+
+    it "raises an error for non single-frame PCI values" do
+      data = [0x10, 0x41, 0x0D, 0x00, 0, 0, 0, 0]
+      expect { decoder.decode(0x7E8, data) }.to raise_error(ArgumentError)
+    end
+  end
 end


### PR DESCRIPTION
## Summary
- enforce single-frame handling by decoding PCI byte and rejecting other frame types
- add specs validating single-frame PCI and rejection of other PCI types

## Testing
- `rubocop -a`
- `bundle exec rspec`


------
https://chatgpt.com/codex/tasks/task_e_68911142f2648320b501c589af8edf70

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of incoming data frames to ensure only supported frame types are processed, with clearer error handling for unsupported types.

* **Tests**
  * Added tests to verify correct handling of supported and unsupported frame types, ensuring errors are raised appropriately for invalid input.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->